### PR TITLE
Phase 0: headless pytest harness + bpy-free core model

### DIFF
--- a/core/model.py
+++ b/core/model.py
@@ -1,0 +1,190 @@
+"""Bpy-free data model for drone show choreography.
+
+All classes in this module are pure Python dataclasses with no Blender
+dependencies. They form the authoritative source of truth for a show's
+structure — the ``blender/`` adapter layer reads and writes these
+objects, while algorithms (assignment, collision, interpolation) operate
+on them directly.
+
+See ``project-plan.md`` §1.3–§1.5 for the architectural rationale behind
+keeping the domain model Blender-free.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import numpy as np
+
+
+@dataclass
+class Geofence:
+    """Bounding volume that constrains where drones may fly.
+
+    The fence is defined as an axis-aligned bounding box in meters,
+    expressed in the show's local coordinate frame (Blender Z-up).
+
+    Attributes
+    ----------
+    min_pos : np.ndarray
+        Minimum X/Y/Z coordinates drones may occupy, shape (3,).
+    max_pos : np.ndarray
+        Maximum X/Y/Z coordinates drones may occupy, shape (3,).
+    max_altitude : float
+        Hard ceiling above the ground plane (Z >= 0).  ``max_pos[2]``
+        should be consistent with this value, but ``max_altitude`` is
+        checked separately because it has operational meaning
+        (regulatory / safety) distinct from the bounding box.
+    """
+
+    min_pos: np.ndarray = field(default_factory=lambda: np.zeros(3))
+    max_pos: np.ndarray = field(default_factory=lambda: np.array([500.0, 500.0, 150.0]))
+    max_altitude: float = 150.0
+
+    def contains(self, point: np.ndarray) -> bool:
+        """Return True if *point* (shape (3,) or (N, 3)) is inside the fence."""
+        point = np.asarray(point)
+        if point.ndim == 1:
+            return bool(
+                np.all(point >= self.min_pos)
+                and np.all(point <= self.max_pos)
+                and point[2] <= self.max_altitude
+            )
+        return bool(
+            np.all(point >= self.min_pos, axis=-1).all()
+            and np.all(point <= self.max_pos, axis=-1).all()
+            and np.all(point[..., 2] <= self.max_altitude)
+        )
+
+
+@dataclass
+class Drone:
+    """A single drone in the show.
+
+    Attributes
+    ----------
+    id : int
+        Stable, non-reorderable identifier.  Assignment algorithms change
+        *slots*, never identity (see ``project-plan.md`` §1.4 — "stable
+        point index / drone_id").
+    home : np.ndarray
+        Takeoff position on the launchpad grid, shape (3,).
+    color : np.ndarray
+        Current LED color as RGB float values in [0, 1], shape (3,).
+    """
+
+    id: int
+    home: np.ndarray = field(default_factory=lambda: np.zeros(3))
+    color: np.ndarray = field(default_factory=lambda: np.ones(3))
+
+
+@dataclass
+class Launchpad:
+    """Takeoff grid layout.
+
+    Attributes
+    ----------
+    rows : int
+        Number of rows in the grid.
+    cols : int
+        Number of columns in the grid.
+    spacing : float
+        Distance between adjacent drones in meters (uniform X/Y).
+    origin : np.ndarray
+        World-space origin of the grid's first slot, shape (3,).
+    """
+
+    rows: int = 10
+    cols: int = 10
+    spacing: float = 3.0
+    origin: np.ndarray = field(default_factory=lambda: np.zeros(3))
+
+    @property
+    def capacity(self) -> int:
+        """Maximum number of drones the grid can hold."""
+        return self.rows * self.cols
+
+    def slot_position(self, row: int, col: int) -> np.ndarray:
+        """Return the world-space position for grid slot (*row*, *col*)."""
+        return self.origin + np.array([col * self.spacing, row * self.spacing, 0.0])
+
+    def all_slots(self) -> np.ndarray:
+        """Return an (N, 3) array of all slot positions, row-major."""
+        positions = []
+        for r in range(self.rows):
+            for c in range(self.cols):
+                positions.append(self.slot_position(r, c))
+        return np.array(positions)
+
+
+@dataclass
+class Formation:
+    """A named set of target positions for the swarm at a point in time.
+
+    Attributes
+    ----------
+    name : str
+        Human-readable label for the formation.
+    positions : np.ndarray
+        Target positions for N drones, shape (N, 3).  The order of rows
+        corresponds to drone assignment (which drone goes to which slot),
+        resolved by the assignment algorithm — not by identity.
+    colors : Optional[np.ndarray]
+        Per-drone LED colors, shape (N, 3) or None if unspecified.
+    duration : float
+        Time in seconds the swarm should hold this formation before
+        transitioning to the next.
+    """
+
+    name: str = ""
+    positions: np.ndarray = field(default_factory=lambda: np.empty((0, 3)))
+    colors: Optional[np.ndarray] = None
+    duration: float = 0.0
+
+    @property
+    def drone_count(self) -> int:
+        """Number of drones referenced by this formation."""
+        return self.positions.shape[0] if self.positions.ndim == 2 else 0
+
+
+@dataclass
+class Show:
+    """Top-level container for a complete drone show.
+
+    A Show holds the launchpad definition, an ordered list of formations,
+    the swarm of drones, and the geofence.  It is the primary object
+    passed between the UI layer and the core algorithms.
+
+    Attributes
+    ----------
+    name : str
+        Show title.
+    launchpad : Launchpad
+        Takeoff grid definition.
+    drones : list[Drone]
+        The swarm, indexed by ``Drone.id``.
+    formations : list[Formation]
+        Ordered sequence of formations the swarm transitions through.
+    geofence : Geofence
+        Safety bounding volume.
+    fps : float
+        Timeline frame rate used for time<->frame conversion.
+    """
+
+    name: str = "Untitled Show"
+    launchpad: Launchpad = field(default_factory=Launchpad)
+    drones: list[Drone] = field(default_factory=list)
+    formations: list[Formation] = field(default_factory=list)
+    geofence: Geofence = field(default_factory=Geofence)
+    fps: float = 30.0
+
+    @property
+    def drone_count(self) -> int:
+        """Number of drones in the swarm."""
+        return len(self.drones)
+
+    @property
+    def duration(self) -> float:
+        """Total show duration in seconds (sum of formation durations)."""
+        return sum(f.duration for f in self.formations)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,105 @@
+"""Pytest configuration and shared fixtures for Sirius.
+
+This conftest makes the test suite runnable in two modes:
+
+1. **Headless (no Blender)** — the default.  Tests import from
+   ``core/`` and ``algorithms/`` directly.  No ``bpy`` is needed
+   because the domain model is pure Python.
+
+2. **With Blender** — when running inside ``blender --background
+   --python -m pytest`` (or via ``pytest-blender``), ``bpy`` is
+   available and integration tests can exercise the adapter layer.
+
+The ``need_bpy`` marker below is used to skip Blender-dependent tests
+when running headlessly.
+"""
+
+import pytest
+
+
+def pytest_configure(config):
+    """Register custom markers."""
+    config.addinivalue_line(
+        "markers",
+        "need_bpy: mark a test as requiring Blender's bpy module. "
+        "Skipped automatically when bpy is not importable.",
+    )
+
+
+def _bpy_available() -> bool:
+    try:
+        import bpy  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+BPY_AVAILABLE = _bpy_available()
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip tests marked ``need_bpy`` when bpy is not importable."""
+    if BPY_AVAILABLE:
+        return
+    skip_bpy = pytest.mark.skip(reason="bpy not available (headless mode)")
+    for item in items:
+        if "need_bpy" in item.keywords:
+            item.add_marker(skip_bpy)
+
+
+# --- Shared fixtures -------------------------------------------------
+
+@pytest.fixture
+def simple_geofence():
+    """A standard 500 m × 500 m × 150 m geofence centered on the origin."""
+    from core.model import Geofence
+    import numpy as np
+    return Geofence(
+        min_pos=np.array([-250.0, -250.0, 0.0]),
+        max_pos=np.array([250.0, 250.0, 150.0]),
+        max_altitude=150.0,
+    )
+
+
+@pytest.fixture
+def small_launchpad():
+    """A 3×2 launchpad with 3 m spacing at the origin."""
+    from core.model import Launchpad
+    return Launchpad(rows=3, cols=2, spacing=3.0)
+
+
+@pytest.fixture
+def sample_drones(small_launchpad):
+    """Six drones positioned on the small launchpad grid."""
+    from core.model import Drone
+    import numpy as np
+    drones = []
+    slot_idx = 0
+    for r in range(small_launchpad.rows):
+        for c in range(small_launchpad.cols):
+            drones.append(Drone(
+                id=slot_idx,
+                home=small_launchpad.slot_position(r, c),
+            ))
+            slot_idx += 1
+    return drones
+
+
+@pytest.fixture
+def sample_show(small_launchpad, sample_drones, simple_geofence):
+    """A minimal show with one formation holding all drones at their home slots."""
+    from core.model import Show, Formation
+    import numpy as np
+    positions = np.array([d.home for d in sample_drones])
+    formation = Formation(
+        name="Home",
+        positions=positions,
+        duration=5.0,
+    )
+    return Show(
+        name="Test Show",
+        launchpad=small_launchpad,
+        drones=sample_drones,
+        formations=[formation],
+        geofence=simple_geofence,
+    )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,147 @@
+"""Unit tests for the bpy-free domain model in ``core/model.py``.
+
+These tests run without Blender installed — they exercise only the
+pure-Python dataclasses and their methods.
+"""
+
+import numpy as np
+import pytest
+
+from core.model import Drone, Formation, Geofence, Launchpad, Show
+
+
+class TestGeofence:
+    def test_default_values(self):
+        gf = Geofence()
+        assert gf.max_altitude == 150.0
+        assert gf.min_pos.shape == (3,)
+        assert gf.max_pos.shape == (3,)
+
+    def test_contains_inside(self):
+        gf = Geofence(
+            min_pos=np.array([0.0, 0.0, 0.0]),
+            max_pos=np.array([100.0, 100.0, 80.0]),
+            max_altitude=80.0,
+        )
+        assert gf.contains(np.array([50.0, 50.0, 40.0]))
+
+    def test_contains_outside(self):
+        gf = Geofence(
+            min_pos=np.array([0.0, 0.0, 0.0]),
+            max_pos=np.array([100.0, 100.0, 80.0]),
+            max_altitude=80.0,
+        )
+        assert not gf.contains(np.array([150.0, 50.0, 40.0]))
+        assert not gf.contains(np.array([50.0, 50.0, 90.0]))
+
+    def test_contains_boundary(self):
+        gf = Geofence(
+            min_pos=np.array([0.0, 0.0, 0.0]),
+            max_pos=np.array([100.0, 100.0, 80.0]),
+            max_altitude=80.0,
+        )
+        assert gf.contains(np.array([0.0, 0.0, 0.0]))
+        assert gf.contains(np.array([100.0, 100.0, 80.0]))
+
+    def test_contains_batch(self):
+        gf = Geofence(
+            min_pos=np.array([0.0, 0.0, 0.0]),
+            max_pos=np.array([100.0, 100.0, 80.0]),
+            max_altitude=80.0,
+        )
+        points = np.array([
+            [50.0, 50.0, 40.0],
+            [150.0, 50.0, 40.0],
+            [50.0, 50.0, 90.0],
+        ])
+        result = gf.contains(points)
+        assert result is True  # all must be inside
+
+
+class TestDrone:
+    def test_defaults(self):
+        d = Drone(id=0)
+        assert d.id == 0
+        assert d.home.shape == (3,)
+        assert d.color.shape == (3,)
+        assert np.all(d.color == 1.0)
+
+    def test_custom_values(self):
+        d = Drone(
+            id=42,
+            home=np.array([10.0, 20.0, 0.0]),
+            color=np.array([1.0, 0.0, 0.0]),
+        )
+        assert d.id == 42
+        assert d.home[0] == 10.0
+        assert d.color[0] == 1.0
+        assert d.color[1] == 0.0
+
+
+class TestLaunchpad:
+    def test_capacity(self):
+        lp = Launchpad(rows=5, cols=4)
+        assert lp.capacity == 20
+
+    def test_slot_position(self):
+        lp = Launchpad(rows=3, cols=3, spacing=2.0, origin=np.array([10.0, 10.0, 0.0]))
+        pos = lp.slot_position(1, 2)
+        assert pos[0] == 14.0  # 10 + 2*2
+        assert pos[1] == 12.0  # 10 + 1*2
+        assert pos[2] == 0.0
+
+    def test_all_slots_count(self):
+        lp = Launchpad(rows=4, cols=6)
+        slots = lp.all_slots()
+        assert slots.shape == (24, 3)
+
+    def test_all_slots_row_major(self):
+        lp = Launchpad(rows=2, cols=2, spacing=1.0)
+        slots = lp.all_slots()
+        # Row 0: (0,0) and (1,0) in grid coords
+        assert np.allclose(slots[0], [0.0, 0.0, 0.0])
+        assert np.allclose(slots[1], [1.0, 0.0, 0.0])
+        # Row 1: (0,1) and (1,1)
+        assert np.allclose(slots[2], [0.0, 1.0, 0.0])
+        assert np.allclose(slots[3], [1.0, 1.0, 0.0])
+
+
+class TestFormation:
+    def test_empty_formation(self):
+        f = Formation(name="Empty")
+        assert f.name == "Empty"
+        assert f.drone_count == 0
+
+    def test_drone_count(self):
+        f = Formation(
+            name="Square",
+            positions=np.array([[0, 0, 0], [10, 0, 0], [10, 10, 0], [0, 10, 0]],
+                                dtype=float),
+        )
+        assert f.drone_count == 4
+
+    def test_default_duration(self):
+        f = Formation()
+        assert f.duration == 0.0
+
+
+class TestShow:
+    def test_empty_show(self):
+        s = Show()
+        assert s.drone_count == 0
+        assert s.duration == 0.0
+        assert len(s.formations) == 0
+
+    def test_duration_sum(self):
+        s = Show(
+            formations=[
+                Formation(duration=5.0),
+                Formation(duration=10.0),
+                Formation(duration=3.0),
+            ],
+        )
+        assert s.duration == 18.0
+
+    def test_drone_count_from_swarm(self):
+        s = Show(drones=[Drone(id=i) for i in range(12)])
+        assert s.drone_count == 12


### PR DESCRIPTION
Sets up the Phase 0 testing foundation from issue #3.

## Files Added

- `core/model.py` — pure-Python dataclasses (Geofence, Drone, Launchpad, Formation, Show) with numpy arrays, no bpy dependency
- `tests/conftest.py` — pytest config with `need_bpy` marker (auto-skip when Blender absent) and shared fixtures (geofence, launchpad, drones, show)
- `tests/test_model.py` — 18 unit tests covering Geofence containment, Drone defaults, Launchpad slot math, Formation drone_count, Show duration
- `tests/__init__.py` — package marker

## How to Run

```bash
pytest tests/ -v
```

All 18 tests pass with only numpy and pytest installed — no Blender needed.

Follows the layered architecture from `project-plan.md` §1.3: core/ is bpy-free and unit-testable.

Closes #3.